### PR TITLE
Points action to correct branch

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -2,7 +2,7 @@ name: Build and deploy eleventy website
 on:
   push:
     branches:
-      - main
+      - master
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
Github action currently point to `main` instead of `master`. This PR fixes that.